### PR TITLE
CB-10857: Camera.getPicture return null for Google Drive (camera 2.1.1)

### DIFF
--- a/src/android/FileHelper.java
+++ b/src/android/FileHelper.java
@@ -59,6 +59,10 @@ public class FileHelper {
         else
             realPath = FileHelper.getRealPathFromURI_API11_And_Above(cordova.getActivity(), uri);
 
+        //Return the URI string if no other type of path has been found
+        if(realPath == null)
+            realPath =  uri.toString();
+
         return realPath;
     }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->
### Platforms affected
### What does this PR do?
### What testing has been done on this change?
### Checklist
- [ ] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

FileHelper getRealPath will fallback to URI string if no other type of
path has been found
